### PR TITLE
Fix compile error

### DIFF
--- a/ruby/ext/ruby_xnd/util.h
+++ b/ruby/ext/ruby_xnd/util.h
@@ -111,7 +111,7 @@ mod(long long a, long long b)
     return r < 0 ? r + b : r;
 }
 
-static inline int
+static inline void
 rb_range_unpack(VALUE range, long long *begin, long long *end, long long *step, size_t size)
 {
   /* FIXME: As of 27 Aug. 2018 Ruby trunk implements step as a property of

--- a/ruby/ext/ruby_xnd/util.h
+++ b/ruby/ext/ruby_xnd/util.h
@@ -118,53 +118,53 @@ rb_range_unpack(VALUE range, long long *begin, long long *end, long long *step, 
      Range and XND will support it as and when it is available. Maybe for 
      now we can implement a #step iterator in a separate method.
   */
- *step = 1;
- VALUE rb_begin = rb_funcall(range, rb_intern("begin"), 0, NULL);
- VALUE rb_end = rb_funcall(range, rb_intern("end"), 0, NULL);
- int exclude_end = RTEST(rb_funcall(range, rb_intern("exclude_end?"), 0, NULL));
- 
- if (RB_TYPE_P(rb_begin, T_FLOAT)) {
-   double value = RFLOAT_VALUE(rb_begin);
+  *step = 1;
+  VALUE rb_begin = rb_funcall(range, rb_intern("begin"), 0, NULL);
+  VALUE rb_end = rb_funcall(range, rb_intern("end"), 0, NULL);
+  int exclude_end = RTEST(rb_funcall(range, rb_intern("exclude_end?"), 0, NULL));
 
-   if (isinf(value)) {
-     *begin = 0;  
-   }
- }
- else {
-   long long temp = NUM2LL(rb_begin);
+  if (RB_TYPE_P(rb_begin, T_FLOAT)) {
+    double value = RFLOAT_VALUE(rb_begin);
 
-   if (temp < 0) {            /* if negative index map to positive. */
-     temp = mod(temp, (long long)size);
-   }
+    if (isinf(value)) {
+      *begin = 0;  
+    }
+  }
+  else {
+    long long temp = NUM2LL(rb_begin);
 
-   *begin = temp;
- }
+    if (temp < 0) {            /* if negative index map to positive. */
+      temp = mod(temp, (long long)size);
+    }
 
- if (RB_TYPE_P(rb_end, T_FLOAT)) {
-   double value = RFLOAT_VALUE(rb_end);
+    *begin = temp;
+  }
 
-   if (isinf(value)) {
-     *end = INT64_MAX;
-     return;
-   }
- }
- else {
-   long long temp = NUM2LL(rb_end);
+  if (RB_TYPE_P(rb_end, T_FLOAT)) {
+    double value = RFLOAT_VALUE(rb_end);
 
-   if (temp < 0) {              /* if negative index map to ppositive. */
-     temp = mod(temp, (long long)size);
-   }
-   
-   *end = temp;
- }
+    if (isinf(value)) {
+      *end = INT64_MAX;
+      return;
+    }
+  }
+  else {
+    long long temp = NUM2LL(rb_end);
 
- /* a[0..0] in Ruby returns the 0th index. 
-    a[0...0] in Ruby returns empty array like a[0:0] in Python.
-    libxnd does not include the last index by default.  
-*/
- if (!exclude_end) {          
-   *end += 1;
- }
+    if (temp < 0) {              /* if negative index map to ppositive. */
+      temp = mod(temp, (long long)size);
+    }
+
+    *end = temp;
+  }
+
+  /* a[0..0] in Ruby returns the 0th index. 
+     a[0...0] in Ruby returns empty array like a[0:0] in Python.
+     libxnd does not include the last index by default.  
+     */
+  if (!exclude_end) {          
+    *end += 1;
+  }
 }
 
 #endif  /* UTIL_H */


### PR DESCRIPTION
This commit fixes the following compile error with `-Wreturn-type`.

```
In file included from ./ruby_xnd_internal.h:52:
./util.h:148:6: error: non-void function 'rb_range_unpack' should return a value [-Wreturn-type]
     return;
     ^
float_pack_unpack.c:76:17: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
  for (i = 0; i < sizeof(float); ++i) {
              ~ ^ ~~~~~~~~~~~~~
float_pack_unpack.c:105:23: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        for (i = 0; i < sizeof(float); ++i) {
                    ~ ^ ~~~~~~~~~~~~~
float_pack_unpack.c:143:17: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
  for (i = 0; i < sizeof(double); ++i) {
              ~ ^ ~~~~~~~~~~~~~~
float_pack_unpack.c:166:23: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        for (i = 0; i < sizeof(double); ++i) {
                    ~ ^ ~~~~~~~~~~~~~~
7 warnings and 1 error generated.
```